### PR TITLE
fix: Correct onclick handlers for collapsible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -904,79 +904,79 @@ select.form-control option {
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.2"></td><td><input type="radio" name="discipline_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.2"></td><td><input type="radio" name="discipline_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.2"></td><td><input type="radio" name="discipline_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.2"></td><td><input type="radio" name="discipline_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.2"></td><td><input type="radio" name="discipline_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.3"></td><td><input type="radio" name="discipline_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.3"></td><td><input type="radio" name="discipline_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.3"></td><td><input type="radio" name="discipline_c_1.3"></td></tr>
+                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.3"></td><td><input type="radio" name="discipline_d_1.3"></td></tr>
+                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.3"></td><td><input type="radio" name="discipline_e_1.3"></td></tr>
                     </tbody>
                 </table>
                 <h5>Cooperation and Team Work</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.2"></td><td><input type="radio" name="cooperation_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.2"></td><td><input type="radio" name="cooperation_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.2"></td><td><input type="radio" name="cooperation_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.2"></td><td><input type="radio" name="cooperation_d_1.2"></td></tr>
+                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.3"></td><td><input type="radio" name="cooperation_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.3"></td><td><input type="radio" name="cooperation_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.3"></td><td><input type="radio" name="cooperation_c_1.3"></td></tr>
+                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.3"></td><td><input type="radio" name="cooperation_d_1.3"></td></tr>
                     </tbody>
                 </table>
                 <h5>Communication in the School</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.2"></td><td><input type="radio" name="communication_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.2"></td><td><input type="radio" name="communication_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.2"></td><td><input type="radio" name="communication_c_1.2"></td></tr>
+                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.3"></td><td><input type="radio" name="communication_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.3"></td><td><input type="radio" name="communication_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.3"></td><td><input type="radio" name="communication_c_1.3"></td></tr>
                     </tbody>
                 </table>
                 <h5>School and Community Relations</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.2"></td><td><input type="radio" name="community_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.2"></td><td><input type="radio" name="community_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.2"></td><td><input type="radio" name="community_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.2"></td><td><input type="radio" name="community_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.2"></td><td><input type="radio" name="community_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.3"></td><td><input type="radio" name="community_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.3"></td><td><input type="radio" name="community_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.3"></td><td><input type="radio" name="community_c_1.3"></td></tr>
+                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.3"></td><td><input type="radio" name="community_d_1.3"></td></tr>
+                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.3"></td><td><input type="radio" name="community_e_1.3"></td></tr>
                     </tbody>
                 </table>
                 <h5>Supervision and Monitoring</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.2"></td><td><input type="radio" name="supervision_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.2"></td><td><input type="radio" name="supervision_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.2"></td><td><input type="radio" name="supervision_c_1.2"></td></tr>
-						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_c_1.2"></td><td><input type="radio" name="supervision_c_1.2"></td></tr>
-                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_d_1.2"></td><td><input type="radio" name="supervision_d_1.2"></td></tr>
+                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.3"></td><td><input type="radio" name="supervision_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.3"></td><td><input type="radio" name="supervision_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.3"></td><td><input type="radio" name="supervision_c_1.3"></td></tr>
+						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_d_1.3"></td><td><input type="radio" name="supervision_d_1.3"></td></tr>
+                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_e_1.3"></td><td><input type="radio" name="supervision_e_1.3"></td></tr>
                     </tbody>
                 </table>
                 <h5>School Records</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.2"></td><td><input type="radio" name="records_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Maintenance of daily classrom register by teachers</td><td><input type="radio" name="records_b_1.2"></td><td><input type="radio" name="records_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.2"></td><td><input type="radio" name="records_c_1.2"></td></tr>
-						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_c_1.2"></td><td><input type="radio" name="records_c_1.2"></td></tr>
-                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_e_1.2"></td><td><input type="radio" name="records_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.3"></td><td><input type="radio" name="records_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Maintenance of daily classrom register by teachers</td><td><input type="radio" name="records_b_1.3"></td><td><input type="radio" name="records_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.3"></td><td><input type="radio" name="records_c_1.3"></td></tr>
+						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_d_1.3"></td><td><input type="radio" name="records_d_1.3"></td></tr>
+                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_e_1.3"></td><td><input type="radio" name="records_e_1.3"></td></tr>
+						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_f_1.3"></td><td><input type="radio" name="records_f_1.3"></td></tr>
+						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_g_1.3"></td><td><input type="radio" name="records_g_1.3"></td></tr>
+						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_h_1.3"></td><td><input type="radio" name="records_h_1.3"></td></tr>
+                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_i_1.3"></td><td><input type="radio" name="records_i_1.3"></td></tr>
                     </tbody>
                 </table>
                 <h5>Health and Hygiene</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.2"></td><td><input type="radio" name="health_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.2"></td><td><input type="radio" name="health_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.2"></td><td><input type="radio" name="health_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.2"></td><td><input type="radio" name="health_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.2"></td><td><input type="radio" name="health_e_1.2"></td></tr>
-						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_e_1.2"></td><td><input type="radio" name="health_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_silnat"></td><td><input type="radio" name="health_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_silnat"></td><td><input type="radio" name="health_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_silnat"></td><td><input type="radio" name="health_c_silnat"></td></tr>
+                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_silnat"></td><td><input type="radio" name="health_d_silnat"></td></tr>
+                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_silnat"></td><td><input type="radio" name="health_e_silnat"></td></tr>
+						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_f_silnat"></td><td><input type="radio" name="health_f_silnat"></td></tr>
                     </tbody>
                 </table>
                 </div>	
@@ -1364,79 +1364,79 @@ select.form-control option {
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_1.2"></td><td><input type="radio" name="discipline_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_1.2"></td><td><input type="radio" name="discipline_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_1.2"></td><td><input type="radio" name="discipline_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_1.2"></td><td><input type="radio" name="discipline_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_1.2"></td><td><input type="radio" name="discipline_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Getting Teachers and Learners to obey rules and regulations</td><td><input type="radio" name="discipline_a_silnat"></td><td><input type="radio" name="discipline_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Handling of disciplinary cases on time and appropriately</td><td><input type="radio" name="discipline_b_silnat"></td><td><input type="radio" name="discipline_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Effecting discipline of misconduct in the School</td><td><input type="radio" name="discipline_c_silnat"></td><td><input type="radio" name="discipline_c_silnat"></td></tr>
+                        <tr><td>d.</td><td>Handling cases of lateness, truancy, etc. in the School</td><td><input type="radio" name="discipline_d_silnat"></td><td><input type="radio" name="discipline_d_silnat"></td></tr>
+                        <tr><td>e.</td><td>Handling cases of professional misconduct by teachers School</td><td><input type="radio" name="discipline_e_silnat"></td><td><input type="radio" name="discipline_e_silnat"></td></tr>
                     </tbody>
                 </table>
                 <h5>Cooperation and Team Work</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_1.2"></td><td><input type="radio" name="cooperation_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_1.2"></td><td><input type="radio" name="cooperation_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_1.2"></td><td><input type="radio" name="cooperation_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_1.2"></td><td><input type="radio" name="cooperation_d_1.2"></td></tr>
+                        <tr><td>a.</td><td>Assigning administrative responsibilities in the school to teachers</td><td><input type="radio" name="cooperation_a_silnat"></td><td><input type="radio" name="cooperation_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Delegating of duties to subordinates</td><td><input type="radio" name="cooperation_b_silnat"></td><td><input type="radio" name="cooperation_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Getting Teachers to work cooperatively to carry out assigned duties</td><td><input type="radio" name="cooperation_c_silnat"></td><td><input type="radio" name="cooperation_c_silnat"></td></tr>
+                        <tr><td>d.</td><td>Encouraging team work in the School</td><td><input type="radio" name="cooperation_d_silnat"></td><td><input type="radio" name="cooperation_d_silnat"></td></tr>
                     </tbody>
                 </table>
                 <h5>Communication in the School</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_1.2"></td><td><input type="radio" name="communication_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_1.2"></td><td><input type="radio" name="communication_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_1.2"></td><td><input type="radio" name="communication_c_1.2"></td></tr>
+                        <tr><td>a.</td><td>Establishing effective channel of communication in the School</td><td><input type="radio" name="communication_a_silnat"></td><td><input type="radio" name="communication_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Guaranteeing freedom of expression in the School</td><td><input type="radio" name="communication_b_silnat"></td><td><input type="radio" name="communication_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Encouraging good communication skills among staff and learners</td><td><input type="radio" name="communication_c_silnat"></td><td><input type="radio" name="communication_c_silnat"></td></tr>
                     </tbody>
                 </table>
                 <h5>School and Community Relations</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_1.2"></td><td><input type="radio" name="community_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_1.2"></td><td><input type="radio" name="community_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_1.2"></td><td><input type="radio" name="community_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_1.2"></td><td><input type="radio" name="community_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_1.2"></td><td><input type="radio" name="community_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Getting the communities to be committed to the school activities</td><td><input type="radio" name="community_a_silnat"></td><td><input type="radio" name="community_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers to relate well with the School community</td><td><input type="radio" name="community_b_silnat"></td><td><input type="radio" name="community_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Institutionalizing SBMC in the School</td><td><input type="radio" name="community_c_silnat"></td><td><input type="radio" name="community_c_silnat"></td></tr>
+                        <tr><td>d.</td><td>Getting SBMC actively involved in the management and provision of facilities in the school</td><td><input type="radio" name="community_d_silnat"></td><td><input type="radio" name="community_d_silnat"></td></tr>
+                        <tr><td>e.</td><td>Involving former pupils in the School activities</td><td><input type="radio" name="community_e_silnat"></td><td><input type="radio" name="community_e_silnat"></td></tr>
                     </tbody>
                 </table>
                 <h5>Supervision and Monitoring</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_1.2"></td><td><input type="radio" name="supervision_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_1.2"></td><td><input type="radio" name="supervision_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_1.2"></td><td><input type="radio" name="supervision_c_1.2"></td></tr>
-						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_c_1.2"></td><td><input type="radio" name="supervision_c_1.2"></td></tr>
-                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_d_1.2"></td><td><input type="radio" name="supervision_d_1.2"></td></tr>
+                        <tr><td>a.</td><td>Assessing Teachers’ lesson plan before delivery</td><td><input type="radio" name="supervision_a_silnat"></td><td><input type="radio" name="supervision_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Getting Teachers supevised during lesson presentations</td><td><input type="radio" name="supervision_b_silnat"></td><td><input type="radio" name="supervision_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Monitoring tests and assignments in the School</td><td><input type="radio" name="supervision_c_silnat"></td><td><input type="radio" name="supervision_c_silnat"></td></tr>
+						<tr><td>d.</td><td>Monitoring of class attendances of teachers and learners</td><td><input type="radio" name="supervision_d_silnat"></td><td><input type="radio" name="supervision_d_silnat"></td></tr>
+                        <tr><td>e.</td><td>Supervision of co-curricular activities in the School</td><td><input type="radio" name="supervision_e_silnat"></td><td><input type="radio" name="supervision_e_silnat"></td></tr>
                     </tbody>
                 </table>
                 <h5>School Records</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_1.2"></td><td><input type="radio" name="records_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Maintenance of daily classrom register by teachers</td><td><input type="radio" name="records_b_1.2"></td><td><input type="radio" name="records_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_1.2"></td><td><input type="radio" name="records_c_1.2"></td></tr>
-						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_c_1.2"></td><td><input type="radio" name="records_c_1.2"></td></tr>
-                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_d_1.2"></td><td><input type="radio" name="records_d_1.2"></td></tr>
-                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_e_1.2"></td><td><input type="radio" name="records_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Maintaining the School Log Book</td><td><input type="radio" name="records_a_silnat"></td><td><input type="radio" name="records_a_silnat"></td></tr>
+                        <tr><td>b.</td><td>Maintenance of daily classrom register by teachers</td><td><input type="radio" name="records_b_silnat"></td><td><input type="radio" name="records_b_silnat"></td></tr>
+                        <tr><td>c.</td><td>Maintaining Weekly Diaries</td><td><input type="radio" name="records_c_silnat"></td><td><input type="radio" name="records_c_silnat"></td></tr>
+						<tr><td>d.</td><td>Maintenance of Teachers' Movement Book</td><td><input type="radio" name="records_d_silnat"></td><td><input type="radio" name="records_d_silnat"></td></tr>
+                        <tr><td>e.</td><td>Keeping of Teachers' Time-book</td><td><input type="radio" name="records_e_silnat"></td><td><input type="radio" name="records_e_silnat"></td></tr>
+						<tr><td>f.</td><td>Keeping of Admission Register</td><td><input type="radio" name="records_f_silnat"></td><td><input type="radio" name="records_f_silnat"></td></tr>
+						<tr><td>g.</td><td>Keeping of Minutes of Staff meetings</td><td><input type="radio" name="records_g_silnat"></td><td><input type="radio" name="records_g_silnat"></td></tr>
+						<tr><td>h.</td><td>Keeping of Examination Records</td><td><input type="radio" name="records_h_silnat"></td><td><input type="radio" name="records_h_silnat"></td></tr>
+                        <tr><td>i.</td><td>Keeping of Visitors Book</td><td><input type="radio" name="records_i_silnat"></td><td><input type="radio" name="records_i_silnat"></td></tr>
                     </tbody>
                 </table>
                 <h5>Health and Hygiene</h5>
                 <table class="data-table">
                     <thead><tr><th>S/N</th><th>ITEM</th><th>Yes</th><th>No</th></tr></thead>
                     <tbody>
-                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.2"></td><td><input type="radio" name="health_a_1.2"></td></tr>
-                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.2"></td><td><input type="radio" name="health_b_1.2"></td></tr>
-                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.2"></td><td><input type="radio" name="health_c_1.2"></td></tr>
-                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.2"></td><td><input type="radio" name="health_d_1.2"></td></tr>
-                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.2"></td><td><input type="radio" name="health_e_1.2"></td></tr>
-						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_e_1.2"></td><td><input type="radio" name="health_e_1.2"></td></tr>
+                        <tr><td>a.</td><td>Keeping the school compound clean</td><td><input type="radio" name="health_a_1.3"></td><td><input type="radio" name="health_a_1.3"></td></tr>
+                        <tr><td>b.</td><td>Keeping and stocking of First Aid box</td><td><input type="radio" name="health_b_1.3"></td><td><input type="radio" name="health_b_1.3"></td></tr>
+                        <tr><td>c.</td><td>Getting the pupils obey hygienic rules</td><td><input type="radio" name="health_c_1.3"></td><td><input type="radio" name="health_c_1.3"></td></tr>
+                        <tr><td>d.</td><td>Getting medical services for the pupils</td><td><input type="radio" name="health_d_1.3"></td><td><input type="radio" name="health_d_1.3"></td></tr>
+                        <tr><td>e.</td><td>Hand Washing Station</td><td><input type="radio" name="health_e_1.3"></td><td><input type="radio" name="health_e_1.3"></td></tr>
+						<tr><td>f.</td><td>Waste Disposal Bin</td><td><input type="radio" name="health_f_1.3"></td><td><input type="radio" name="health_f_1.3"></td></tr>
                     </tbody>
                 </table>
                 </div>	   
@@ -3789,7 +3789,7 @@ select.form-control option {
 }
 
     </style>
-    <script src="./Audit App_files/dropdown.js.download"></script>
+    <script src="./Audit App_files/dropdown.js.download?v=2"></script>
     <script>
     // Navigation logic for landing/surveys
     async function showSurvey(survey) {


### PR DESCRIPTION
The `silnatSection` and `silat_1.3Section` were using duplicate `name` attributes for their collapsible sections. This caused the `toggleSection` JavaScript function to target the wrong elements, preventing the sections in the SILNAT form from expanding.

This commit corrects the `name` attributes to be unique for each section, ensuring that the correct section is toggled when you click on the header.